### PR TITLE
Print all password entries in table format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -286,6 +286,29 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "cli-table"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbb116d9e2c4be7011360d0c0bee565712c11e969c9609b25b619366dc379d"
+dependencies = [
+ "cli-table-derive",
+ "csv",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "cli-table-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af3bfb9da627b0a6c467624fb7963921433774ed435493b5c08a3053e829ad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "clipboard"
@@ -459,6 +482,27 @@ dependencies = [
  "x25519-dalek",
  "xsalsa20poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -733,6 +777,7 @@ dependencies = [
  "bcrypt",
  "bincode",
  "clap",
+ "cli-table",
  "clipboard",
  "colour",
  "criterion",
@@ -896,7 +941,7 @@ checksum = "8b86292cf41ccfc96c5de7165c1c53d5b4ac540c5bab9d1857acbe9eba5f1a0b"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1102,7 +1147,7 @@ checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1172,6 +1217,17 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
@@ -1179,6 +1235,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1198,7 +1263,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1222,6 +1287,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "universal-hash"
@@ -1288,7 +1359,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -1310,7 +1381,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1495,5 +1566,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.75"
 bcrypt = "0.15.0"
 bincode = "1.3.3"
 clap = { version = "4.4.2", features = ["derive"] }
+cli-table = "0.4.7"
 clipboard = "0.5.0"
 colour = "0.7.0"
 once_cell = "1.18.0"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -119,10 +119,19 @@ pub struct UpdateArgs {
 pub struct ListArgs {}
 
 pub fn list_entries(master_password: MasterPassword<Verified>) -> anyhow::Result<()> {
-    // TODO: Make a table to list passwords
     let manager = PasswordStore::new(PASS_ENTRY_STORE.to_path_buf(), master_password)?;
 
-    dbg!(manager);
+    match manager.get_table() {
+        Ok(table) => {
+            println!("{table}");
+        }
+        Err(PasswordStoreError::NoEntryAvailable) => {
+            colour::e_red_ln!("No entry available");
+        }
+        Err(error) => {
+            return Err(error.into());
+        }
+    };
 
     Ok(())
 }
@@ -162,6 +171,7 @@ pub struct GenArgs {
 }
 
 impl GenArgs {
+    /// Generate random password based on flags
     pub fn generate_password(self) {
         // If no flags is given then generate a password including Uppercase, lowercase & digits
         let password_generator = if self.digits || self.lowercase || self.uppercase || self.symbols

--- a/src/pass/entry.rs
+++ b/src/pass/entry.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::pass::util::generate_random_password;
+use cli_table::{format::Justify, Cell};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Password {
@@ -60,9 +61,25 @@ impl PasswordEntry {
         }
     }
 
-    // Change password in current entry
+    /// Change password in current entry
     pub fn change_password(&mut self, password: impl AsRef<str>) {
         self.password = Password::new(Some(password.as_ref()));
+    }
+
+    /// Create table for [PasswordEntry]
+    pub fn table(&self) -> Vec<cli_table::CellStruct> {
+        let service = self.service.clone();
+        let username = self.username.clone().unwrap_or("None".to_string());
+        let password =
+            String::from_utf8(self.password.password.clone()).unwrap_or("None".to_string());
+        let notes = self.other.clone().unwrap_or("None".to_string());
+
+        vec![
+            service.cell().justify(Justify::Center),
+            username.cell().justify(Justify::Center),
+            password.cell().justify(Justify::Center),
+            notes.cell().justify(Justify::Center),
+        ]
     }
 }
 

--- a/src/pass/entry.rs
+++ b/src/pass/entry.rs
@@ -70,14 +70,11 @@ impl PasswordEntry {
     pub fn table(&self) -> Vec<cli_table::CellStruct> {
         let service = self.service.clone();
         let username = self.username.clone().unwrap_or("None".to_string());
-        let password =
-            String::from_utf8(self.password.password.clone()).unwrap_or("None".to_string());
         let notes = self.other.clone().unwrap_or("None".to_string());
 
         vec![
             service.cell().justify(Justify::Center),
             username.cell().justify(Justify::Center),
-            password.cell().justify(Justify::Center),
             notes.cell().justify(Justify::Center),
         ]
     }

--- a/src/pass/store.rs
+++ b/src/pass/store.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
-use cli_table::{Cell, CellStruct, Style, Table, TableDisplay};
+use cli_table::format::Justify;
+use cli_table::{Cell, Style, Table, TableDisplay};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_encrypt::{
@@ -180,13 +181,19 @@ impl PasswordStore {
             let table = self
                 .passwords
                 .iter()
-                .map(|p| p.table())
-                .collect::<Vec<Vec<CellStruct>>>()
+                .enumerate()
+                .map(|(index, data)| {
+                    let mut table = data.table();
+                    let serial = (index + 1).to_string().cell().justify(Justify::Center);
+                    table.insert(0, serial);
+                    table
+                })
+                .collect::<Vec<Vec<_>>>()
                 .table()
                 .title(vec![
+                    "Serial no.".cell().bold(true),
                     "Service".cell().bold(true),
                     "Username".cell().bold(true),
-                    "Password".cell().bold(true),
                     "Notes".cell().bold(true),
                 ])
                 .bold(true)

--- a/src/pass/store.rs
+++ b/src/pass/store.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use cli_table::{Cell, CellStruct, Style, Table, TableDisplay};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_encrypt::{
@@ -44,6 +45,9 @@ pub enum PasswordStoreError {
 
     #[error("Encrypt Error: {0}")]
     UnableToEncryptError(String),
+
+    #[error("No available entry")]
+    NoEntryAvailable,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -166,6 +170,31 @@ impl PasswordStore {
 
     pub fn fuzzy_find() -> Vec<PasswordEntry> {
         unimplemented!();
+    }
+
+    /// Table
+    pub fn get_table(&self) -> Result<TableDisplay, PasswordStoreError> {
+        if self.passwords.is_empty() {
+            Err(PasswordStoreError::NoEntryAvailable)
+        } else {
+            let table = self
+                .passwords
+                .iter()
+                .map(|p| p.table())
+                .collect::<Vec<Vec<CellStruct>>>()
+                .table()
+                .title(vec![
+                    "Service".cell().bold(true),
+                    "Username".cell().bold(true),
+                    "Password".cell().bold(true),
+                    "Notes".cell().bold(true),
+                ])
+                .bold(true)
+                .display()
+                .expect("Unable to list entries");
+
+            Ok(table)
+        }
     }
 }
 


### PR DESCRIPTION
Used [cli-table](https://crates.io/crates/cli-table) crate and create methods to perform so

Now look like: 
```bash
tan@arch ~/D/P/pass (29-print-table-for-showing-password-entries)> cargo run --release -- list
   Compiling pass v0.1.0 (/home/tan/Documents/Projects/pass)
    Finished release [optimized] target(s) in 4.76s
     Running `target/release/pass list`
Enter Master password: 
+---------+----------+--------------+-------+
| Service | Username | Password     | Notes |
+---------+----------+--------------+-------+
| netfilx |  ishan   | x8NtfPs1r79) | None  |
+---------+----------+--------------+-------+
| netflix | tanveer  | hg3vNJlq6dO3 | None  |
+---------+----------+--------------+-------+
|   git   |  ishan   | password123@ | None  |
+---------+----------+--------------+-------+
|   git   |   tan    |  hello123@   | None  |
+---------+----------+--------------+-------+
```